### PR TITLE
support multiple private github repos in secret.conf

### DIFF
--- a/R/github_install.R
+++ b/R/github_install.R
@@ -9,10 +9,22 @@ github_install <- function(gitrepo, gituser, gitbranch = "master"){
   
   #For private repos
   mysecret <- gitsecret();
-  if(length(mysecret) && length(mysecret$auth_token) && nchar(mysecret$auth_token)){
-    auth = paste0(", auth_token=", deparse(mysecret$auth_token))
+  if(length(mysecret) && length(mysecret$auth_token) &&
+     any(nchar(mysecret$auth_token))){
+      if(length(mysecret$auth_token) == 1) {
+          ## one auth_token provided, assume it is for the given
+          ## gitrepo
+          auth <- paste0(", auth_token=", deparse(mysecret$auth_token))
+      } else if(length(mysecret$auth_token[[gituser]])) {
+          ## multiple pats are available, choose the one for this gitrepo 
+          ## name
+          auth <- paste0(", auth_token=", deparse(mysecret$auth_token[[gituser]]))
+      } else {
+          ## multiple pats are available, but none with name of this repo
+          auth <- "";
+      }
   } else {
-    auth = "";
+      auth <- "";
   }
   
   #Dependencies = TRUE would also install currently loaded packages.


### PR DESCRIPTION
To support multiple private Github repos, secret.conf's auth_token can optionally be an object containing account : token pairs. 

"auth_token" : {"github_account1" : "personal_access_token1",
                        "github_account2" : "personal_access_token2"} 

Note that the names of the properties in the object are the github _account_ name, not the repository names.  The function still honors the situation where auth_token is simply a string. 
