### PR TITLE
Use openssl's cryptographically secure RNG

### DIFF
--- a/R/session.R
+++ b/R/session.R
@@ -2,9 +2,8 @@ session <- local({
 
   #generates a random session hash
   generate <- function(){
-    characters <- c(0:9, letters[1:6]);
     while(file.exists(sessiondir(
-      hash <- paste(c("x0", sample(characters, config("key.length"), replace=TRUE)), collapse="")
+      hash <- paste0("x0", system( paste("openssl rand -hex",config("key.length")/2), intern = T ) )
     ))){}
     hash;
   }  


### PR DESCRIPTION
So simply going straight to openssl seems to be the recommend course of action in a number of R packages dealing with cryptographically insecure RNG (e.g. [randaes](http://cran.r-project.org/web/packages/randaes/index.html)  and [digest](http://cran.r-project.org/web/packages/digest/digest.pdf)).

Re #95 I proposed the necessary edits, but they would come at some cost, using openssl via system calls is ~176 times slower. Maybe the RNG generator could be pickable through a config option? In my case using cryptographically secure keys would really be imperative, but MMV. Maybe OpenCPU should default to the more secure version though...

``` r
system.time({
    for(i in 1:5000) {
    hash <- paste0("x0", system( paste("openssl rand -hex",64/2), intern = T ) )
 }
 })
##   user  system elapsed 
## 12.712   8.402  21.942 
characters <- c(0:9, letters[1:6]);
system.time({
    for(i in 1:5000) {
        hash <- paste(c("x0", sample(characters, 64, replace=TRUE)), collapse="")
    }
 })
##   user  system elapsed 
##  0.122   0.003   0.124 
4.357/0.013
## [1] 176.9516
```
