### PR TITLE
split ocpu-store path

### DIFF
--- a/R/httpget_tmp.R
+++ b/R/httpget_tmp.R
@@ -11,6 +11,7 @@ httpget_tmp <- function(requri){
     res$checkmethod();
     res$checktrail();
     allfiles <- list.files(ocpu_store(), pattern=paste("^", prefix, sep=""));
+
     res$sendlist(allfiles);
   }
 
@@ -21,7 +22,7 @@ httpget_tmp <- function(requri){
     reqtail <- c("R", parts[2], reqtail)
   }
 
-  sessionpath <- file.path(ocpu_store(), reqhead);
+  sessionpath <- file.path(ocpu_store(), splitpath(reqhead));
 
   #set cache value
   res$setcache("tmp");

--- a/R/serve.R
+++ b/R/serve.R
@@ -14,7 +14,7 @@ serve <- function(REQDATA, run_worker = NULL){
       on.exit({
         gc() #GC on windows closes open file descriptors before moving dir!
         if(file.exists(file.path(mytmp, "workspace/.RData")))
-          file_move(file.path(mytmp, "workspace"), sessiondir(hash))
+          dir.move(file.path(mytmp, "workspace"), sessiondir(hash))
       }, add = TRUE)
       on.exit(unlink(mytmp, recursive = TRUE), add = TRUE)
       expr <- c(
@@ -60,7 +60,7 @@ serve <- function(REQDATA, run_worker = NULL){
   if(REQDATA$METHOD == "POST"){
     on.exit({
       if(file.exists(file.path(mytmp, "workspace")))
-        file_move(file.path(mytmp, "workspace"), sessiondir(hash))
+        dir.move(file.path(mytmp, "workspace"), sessiondir(hash))
     }, add = TRUE)
   }
   on.exit(unlink(mytmp, recursive = TRUE), add = TRUE)


### PR DESCRIPTION
Hi,

In our environment we want to preserve ocpu sessions as long as possible which leads to a large number of session dirs in ocpu-store. I think it is more convenient to make hirarchical structure and I made a corresponding simple fix. 

I know that it breaks session listing, but that should be fixable (and I'm not sure that listing all sessions is neccessary, I think it allows users to get information from other user sessions).