### PR TITLE
Create smaller, scalable SVG's with svglite

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ Encoding: UTF-8
 URL: https://www.opencpu.org (website)
     https://github.com/opencpu/opencpu#readme (devel)
 BugReports: https://github.com/opencpu/opencpu/issues
-Depends:	
+Depends: 
     R (>= 3.0.0)
 Imports:
     evaluate (>= 0.12),
@@ -30,7 +30,8 @@ Suggests:
     haven,
     feather,
     pander,
-    R.rsp
+    R.rsp,
+    svglite
 SystemRequirements: pandoc, apparmor (optional)
 VignetteBuilder: knitr, R.rsp
 Description: A system for embedded scientific computing and reproducible research with R.

--- a/R/httpget_object.R
+++ b/R/httpget_object.R
@@ -44,6 +44,7 @@ httpget_object <- local({
       "png" = httpget_object_png(object),
       "pdf" = httpget_object_pdf(object, objectname),
       "svg" = httpget_object_svg(object, objectname),
+      "svglite" = httpget_object_svglite(object, objectname),
       res$notfound(message=paste("Invalid output format for objects:", reqformat))
     )
   }
@@ -229,6 +230,16 @@ httpget_object <- local({
     mytmp <- tempfile();
     do.call(function(width=11.69, height=8.27, pointsize=12, ...){
       svg(file=mytmp, width=as.numeric(width), height=as.numeric(height), pointsize=as.numeric(pointsize), ...);
+    }, req$get());
+    on.exit(dev.off())
+    res$setheader("Content-Type", "image/svg+xml");
+    try_print_plot(object, mytmp)
+  }
+
+  httpget_object_svglite <- function(object, objectname){
+    mytmp <- tempfile();
+    do.call(function(width=11.69, height=8.27, pointsize=12, ...){
+      svglite::svglite(file=mytmp, width=as.numeric(width), height=as.numeric(height), pointsize=as.numeric(pointsize), ...);
     }, req$get());
     on.exit(dev.off())
     res$setheader("Content-Type", "image/svg+xml");

--- a/R/session.R
+++ b/R/session.R
@@ -64,7 +64,7 @@ session_eval <- function(input, args = NULL, storeval=FALSE, format="list"){
   res$setstatus(201)
 
   # Shortcuts to get output immediately
-  if(format %in% c("png", "svg", "pdf")){
+  if(format %in% c("png", "svg", "pdf", "svglite")){
     myplots <- extract(output$res, "graphics")
     if(length(myplots) < 1)
       res$error("Function call did not generate any graphics", 400)


### PR DESCRIPTION
This PR suggests adding an `svglite` shortcut. 

The standard `svg` device in `opencpu` (`grDevices::svg()`) produces files that have a `width` and `height` parameter set. If the `svg` function writes `grid` graphics that have fixed scales (`cm`, `in`), the result is a static figure with the stated dimensions.

The `svglite::svglite()` function does not set `width` and `height` <https://r-lib.github.io/svglite/articles/scaling.html>, and hence the figures become scalable in the browser. In addition, the file sizes are substantially smaller. 

My suggestion is to add a `svglite` shortcut that makes `svglite()` available in `opencpu`. In practice, we might then replace a `grid` graphics figure designed at 8 by 6 inches

```
curl https://cloud.opencpu.org/ocpu/tmp/x0468b7ab/graphics/last/svg?width=8&height=6
```

by 

```
curl https://cloud.opencpu.org/ocpu/tmp/x0468b7ab/graphics/last/svglite?width=8&height=6
```

The first figure does not adapt to the browser size, but the second figure does.
