### PR TITLE
add stacktrace to error reporting

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,6 +20,7 @@ Imports:
     webutils (>= 0.6),
     curl (>= 4.0),
     rappdirs,
+    rlang,
     zip,
     mime,
     protolite,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,6 +22,7 @@ Imports:
     rappdirs,
     rlang,
     vctrs,
+    methods,
     zip,
     mime,
     protolite,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,6 +21,7 @@ Imports:
     curl (>= 4.0),
     rappdirs,
     rlang,
+    vctrs,
     zip,
     mime,
     protolite,

--- a/R/evaluate.R
+++ b/R/evaluate.R
@@ -1,9 +1,9 @@
 evaluate_input <- function(input, args = NULL, storeval = FALSE) {
 
   #setup handler
-  rlang:::poke_last_error(NULL) # reset all previous errors if any
+  error_object <- NULL
   myhandler <- evaluate::new_output_handler(value = function(myval, visible = TRUE){
-    if(isTRUE(storeval)){
+    if(isTRUE(storeval) && is.null(error_object)){
       assign(".val", myval, sessionenv);
     }
     if(isTRUE(visible)){
@@ -16,7 +16,9 @@ evaluate_input <- function(input, args = NULL, storeval = FALSE) {
       }
     }
     invisible()
-  }, error = rlang::entrace)
+  }, error = function(e){
+    error_object <<- e
+  })
 
   #create session for output objects
   if(!length(args)){
@@ -35,7 +37,7 @@ evaluate_input <- function(input, args = NULL, storeval = FALSE) {
   }
   res <- evaluate::evaluate(input = input, envir = sessionenv, stop_on_error = 1, output_handler = myhandler)
 
-  error_object <- rlang:::peek_last_error()
+  error_object <- rlang::cnd_entrace(error_object)
 
   if (!is.null(error_object$trace)) {
     tr <- error_object$trace

--- a/R/evaluate.R
+++ b/R/evaluate.R
@@ -12,7 +12,7 @@ evaluate_input <- function(input, args = NULL, storeval = FALSE) {
         cat("List of length ", length(myval), "\n")
         cat(paste("[", names(myval), "]", sep="", collapse="\n"))
       } else {
-        getFromNamespace("render", "evaluate")(myval)
+        evaluate_render(myval)
       }
     }
     invisible()
@@ -61,4 +61,9 @@ evaluate_input <- function(input, args = NULL, storeval = FALSE) {
     sessionenv = sessionenv,
     error = error_object
   )
+}
+
+# Copied from evaluate:::render
+evaluate_render <- function(x){
+  if (isS4(x)) methods::show(x) else print(x)
 }

--- a/R/evaluate.R
+++ b/R/evaluate.R
@@ -17,6 +17,19 @@ evaluate_input <- function(input, args = NULL, storeval = FALSE) {
     }
     invisible()
   }, error = function(e){
+    tr <- sys.calls()
+
+    isErrorHandler <- vapply(tr,
+                             function(x) identical(x[[1]], quote(.handleSimpleError)), logical(1))
+    errorHandlerIndex <- min(c(length(isErrorHandler)+1, which(isErrorHandler)))
+
+    tr <- head(tr, errorHandlerIndex-1)
+    isEval <- vapply(tr,
+                     function(x) identical(x[[1]], quote(eval)), logical(1))
+    lastEvalIndex <- max(c(0, which(isEval)))
+    tr <- tail(tr, length(tr) - lastEvalIndex)
+
+    e$trace <- tr
     error_object <<- e
   })
 

--- a/R/evaluate.R
+++ b/R/evaluate.R
@@ -49,11 +49,6 @@ evaluate_input <- function(input, args = NULL, storeval = FALSE) {
   )
 }
 
-# Copied from evaluate:::render
-evaluate_render <- function(x){
-  if (isS4(x)) methods::show(x) else print(x)
-}
-
 add_rlang_trace <- function(error_object){
   err <- rlang::cnd_entrace(error_object)
 
@@ -70,8 +65,22 @@ add_rlang_trace <- function(error_object){
 
     trIdx <- rlang::seq2(lastOverheadIndex + 1, errorHandlerIndex-1)
 
-    err$trace <- rlang:::trace_slice(tr, trIdx)
+    err$trace <- rlang_trace_slice(tr, trIdx)
 
   }
   return(err)
+}
+
+# Copied from rlang:::trace_slice
+rlang_trace_slice <- function (trace, i) {
+  i <- vctrs::vec_as_location(i, nrow(trace))
+  parent <- match(trace$parent, i, nomatch = 0)
+  out <- vctrs::vec_slice(trace, i)
+  out$parent <- parent[i]
+  out
+}
+
+# Copied from evaluate:::render
+evaluate_render <- function(x){
+  if (isS4(x)) methods::show(x) else print(x)
 }

--- a/R/evaluate.R
+++ b/R/evaluate.R
@@ -37,7 +37,7 @@ evaluate_input <- function(input, args = NULL, storeval = FALSE) {
   }
   res <- evaluate::evaluate(input = input, envir = sessionenv, stop_on_error = 1, output_handler = myhandler)
 
-  if(length(error_object) && length(error_object$call)){
+  if(length(error_object) && length(error_object$call) && isTRUE(config("error.backtrace"))){
     error_object <- add_rlang_trace(error_object)
   }
 

--- a/R/evaluate.R
+++ b/R/evaluate.R
@@ -3,7 +3,7 @@ evaluate_input <- function(input, args = NULL, storeval = FALSE) {
   #setup handler
   rlang:::poke_last_error(NULL) # reset all previous errors if any
   myhandler <- evaluate::new_output_handler(value = function(myval, visible = TRUE){
-    if(isTRUE(storeval) && is.null(error_object)){
+    if(isTRUE(storeval)){
       assign(".val", myval, sessionenv);
     }
     if(isTRUE(visible)){
@@ -48,7 +48,7 @@ evaluate_input <- function(input, args = NULL, storeval = FALSE) {
     isOverheadCall <- tr$namespace %in% c("evaluate", "opencpu")
     lastOverheadIndex <- max(c(0, which(isOverheadCall)))
 
-    trIdx <- seq2(lastOverheadIndex + 1, errorHandlerIndex-1)
+    trIdx <- rlang::seq2(lastOverheadIndex + 1, errorHandlerIndex-1)
 
     error_object$trace <- rlang:::trace_slice(tr, trIdx)
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -199,9 +199,8 @@ format_user_error <- function(e){
   errmsg <- e$message;
   if(length(e$call)){
     errmsg <- c(errmsg, "", "In call:", deparse(e$call), "")
-    if (!is.null(e$trace) > 0) {
-      trace_lines <- capture.output(print(e$trace))
-      errmsg <- c(errmsg, "Stacktrace:", trace_lines)
+    if (length(e$trace)) {
+      errmsg <- c(errmsg, "Stacktrace:", format(e$trace))
     }
   }
   return(errmsg)

--- a/R/utils.R
+++ b/R/utils.R
@@ -198,7 +198,12 @@ deparse_query <- function(x){
 format_user_error <- function(e){
   errmsg <- e$message;
   if(length(e$call)){
-    errmsg <- c(errmsg, "", "In call:", deparse(e$call));
+    errmsg <- c(errmsg, "", "In call:", deparse(e$call), "")
+    if (length(e$trace) > 0) {
+      trace_lines <- unlist(lapply(seq_along(e$trace),
+                                   function(i) c(paste0(i, ": "), deparse(e$trace[[i]]))))
+      errmsg <- c(errmsg, "Stacktrace:", trace_lines)
+    }
   }
   return(errmsg)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -197,12 +197,10 @@ deparse_query <- function(x){
 
 format_user_error <- function(e){
   errmsg <- e$message;
-  if(length(e$call)){
+  if(length(e$call) && isTRUE(config("error.showcall")))
     errmsg <- c(errmsg, "", "In call:", deparse(e$call), "")
-    if (length(e$trace) && length(e$trace$call)) {
-      errmsg <- c(errmsg, "Stacktrace:", format(e$trace))
-    }
-  }
+  if (length(e$trace) && length(e$trace$call) && isTRUE(config("error.backtrace")))
+    errmsg <- c(errmsg, "Backtrace:", format(e$trace))
   return(errmsg)
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -199,7 +199,7 @@ format_user_error <- function(e){
   errmsg <- e$message;
   if(length(e$call)){
     errmsg <- c(errmsg, "", "In call:", deparse(e$call), "")
-    if (length(e$trace)) {
+    if (length(e$trace) && length(e$trace$call)) {
       errmsg <- c(errmsg, "Stacktrace:", format(e$trace))
     }
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -199,9 +199,8 @@ format_user_error <- function(e){
   errmsg <- e$message;
   if(length(e$call)){
     errmsg <- c(errmsg, "", "In call:", deparse(e$call), "")
-    if (length(e$trace) > 0) {
-      trace_lines <- unlist(lapply(seq_along(e$trace),
-                                   function(i) c(paste0(i, ": "), deparse(e$trace[[i]]))))
+    if (!is.null(e$trace) > 0) {
+      trace_lines <- capture.output(print(e$trace))
       errmsg <- c(errmsg, "Stacktrace:", trace_lines)
     }
   }

--- a/inst/config/defaults.conf
+++ b/inst/config/defaults.conf
@@ -7,6 +7,7 @@
     "enable.post.code": true,
     "enable.rlimits" : true,
     "error.showcall": true,
+    "error.backtrace": true,
     "smtp.server" : "localhost",
     "smtp.use.ssl" : "no",
     "httpcache.post": 300,


### PR DESCRIPTION
Hi,

I've implemented a small patch that adds reporting of stack traces of the errors (fixes #1). It's not perfect, but I think it get the work done: it tries to strip `sys.calls()` output, so that only the meaningful calls are kept, after the last `eval` up to the error handler. 

Let me know what you think.

