### PR TITLE
fix: correct 'occured' to 'occurred' typo in build failure email

### DIFF
--- a/R/email.R
+++ b/R/email.R
@@ -34,7 +34,7 @@ create_email <- function(success, output, payload, mail_owner) {
       paste0("Build ", commitname, " successful: ", url_path(public_url(), "apps", what))
     }
   } else {
-    paste("Build", commitname, "failed. Either an error occured during package installation, or the package name does not match the name of the Github repository.");
+    paste("Build", commitname, "failed. Either an error occurred during package installation, or the package name does not match the name of the Github repository.");
   }
 
   # Create recipient formats


### PR DESCRIPTION
Fixes typo in build failure email notification sent to users.

File: R/email.R:37
Before: Either an error occured during package installation
After: Either an error occurred during package installation